### PR TITLE
Fix Yahoo Finance 1w Timeframe Error

### DIFF
--- a/web_interface.py
+++ b/web_interface.py
@@ -55,9 +55,6 @@ class WebTradingAnalyzer:
             'DXY': 'DX-Y.NYB',  # US Dollar Index
         }
         
-        # Available timeframes
-        self.timeframes = ['1m', '5m', '15m', '30m', '1h', '4h', '1d']
-        
         # Yahoo Finance interval mapping
         self.yfinance_intervals = {
             '1m': '1m',
@@ -66,7 +63,9 @@ class WebTradingAnalyzer:
             '30m': '30m',
             '1h': '1h',
             '4h': '4h',  # yfinance supports 4h natively!
-            '1d': '1d'
+            '1d': '1d',
+            '1w': '1wk',
+            '1mo': '1mo'
         }
     
         # Load persisted custom assets
@@ -265,6 +264,10 @@ class WebTradingAnalyzer:
                 display_timeframe += 'in'
             elif timeframe.endswith('d'):
                 display_timeframe += 'ay'
+            elif timeframe == '1w':
+                display_timeframe = '1 week'
+            elif timeframe == '1mo':
+                display_timeframe = '1 month'
             
             # Create initial state
             initial_state = {
@@ -387,6 +390,7 @@ class WebTradingAnalyzer:
             "4h": {"max_days": 730, "description": "4 hour data: max 730 days"},
             "1d": {"max_days": 730, "description": "1 day data: max 730 days"},
             "5d": {"max_days": 60, "description": "5 day data: max 60 days"},
+            "1w": {"max_days": 730, "description": "1 week data: max 730 days"},
             "1wk": {"max_days": 730, "description": "1 week data: max 730 days"},
             "1mo": {"max_days": 730, "description": "1 month data: max 730 days"},
             "3mo": {"max_days": 730, "description": "3 month data: max 730 days"}


### PR DESCRIPTION
## Problem
Users experienced a `YFPricesMissingError` when selecting the "1w" (weekly) timeframe in the web interface. The error occurred because:
- The web interface was sending `interval=1w` to Yahoo Finance API
- Yahoo Finance expects `interval=1wk` for weekly data (not `1w`)
- The backend wasn't properly mapping user-facing timeframes to Yahoo Finance intervals

## Error Message
YFPricesMissingError('possibly delisted; no price data found (1w 2025-08-26 00:00:00 -> 2025-09-25 11:54:56.758320) (Yahoo error = "Invalid input - interval=1w is not supported. Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 4h, 1d, 5d, 1wk, 1mo, 3mo]")')


## Solution
1. **Fixed interval mapping**: Added proper mapping from `1w` → `1wk` and `1mo` → `1mo` in `yfinance_intervals`
2. **Cleaned up timeframes**: Removed redundant `timeframes` list since interval validation is handled by `yfinance_intervals`
3. **Enhanced display formatting**: Added proper display names ("1 week", "1 month") for the new timeframes
4. **Added date limits**: Configured appropriate date range limits for weekly data (730 days max)
