### PR TITLE
Upgrade default MiniMax model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ elif provider == "qwen":
 elif provider == "minimax":
     # Set default MiniMax models (204K context window)
     if not analyzer.config["agent_llm_model"].startswith("MiniMax"):
-        analyzer.config["agent_llm_model"] = "MiniMax-M2.7"
+        analyzer.config["agent_llm_model"] = "MiniMax-M3"
     if not analyzer.config["graph_llm_model"].startswith("MiniMax"):
-        analyzer.config["graph_llm_model"] = "MiniMax-M2.7"
+        analyzer.config["graph_llm_model"] = "MiniMax-M3"
 
 else:
     # Set default OpenAI models if not already set to OpenAI models

--- a/README_CN.md
+++ b/README_CN.md
@@ -191,9 +191,9 @@ elif provider == "qwen":
 elif provider == "minimax":
     # Set default MiniMax models (204K context window)
     if not analyzer.config["agent_llm_model"].startswith("MiniMax"):
-        analyzer.config["agent_llm_model"] = "MiniMax-M2.7"
+        analyzer.config["agent_llm_model"] = "MiniMax-M3"
     if not analyzer.config["graph_llm_model"].startswith("MiniMax"):
-        analyzer.config["graph_llm_model"] = "MiniMax-M2.7"
+        analyzer.config["graph_llm_model"] = "MiniMax-M3"
 
 else:
     # Set default OpenAI models if not already set to OpenAI models

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -383,8 +383,8 @@ class TestWebInterfaceProviderUpdate(unittest.TestCase):
         )
         data = resp.get_json()
         self.assertTrue(data.get("success"))
-        self.assertEqual(analyzer.config["agent_llm_model"], "MiniMax-M2.7")
-        self.assertEqual(analyzer.config["graph_llm_model"], "MiniMax-M2.7")
+        self.assertEqual(analyzer.config["agent_llm_model"], "MiniMax-M3")
+        self.assertEqual(analyzer.config["graph_llm_model"], "MiniMax-M3")
 
     @patch("web_interface.TradingGraph")
     def test_update_provider_minimax_cn(self, mock_tg_class):
@@ -406,8 +406,8 @@ class TestWebInterfaceProviderUpdate(unittest.TestCase):
         )
         data = resp.get_json()
         self.assertTrue(data.get("success"))
-        self.assertEqual(analyzer.config["agent_llm_model"], "MiniMax-M2.7")
-        self.assertEqual(analyzer.config["graph_llm_model"], "MiniMax-M2.7")
+        self.assertEqual(analyzer.config["agent_llm_model"], "MiniMax-M3")
+        self.assertEqual(analyzer.config["graph_llm_model"], "MiniMax-M3")
 
     @patch("web_interface.TradingGraph")
     def test_update_provider_invalid(self, mock_tg_class):
@@ -478,8 +478,8 @@ class TestWebInterfaceProviderUpdate(unittest.TestCase):
         self.assertEqual(os.environ.get("MINIMAX_CN_API_KEY"), "test-mm-cn-key")
         self.assertEqual(analyzer.config["agent_llm_provider"], "minimax_cn")
         self.assertEqual(analyzer.config["graph_llm_provider"], "minimax_cn")
-        self.assertEqual(analyzer.config["agent_llm_model"], "MiniMax-M2.7")
-        self.assertEqual(analyzer.config["graph_llm_model"], "MiniMax-M2.7")
+        self.assertEqual(analyzer.config["agent_llm_model"], "MiniMax-M3")
+        self.assertEqual(analyzer.config["graph_llm_model"], "MiniMax-M3")
         self.assertEqual(mock_tg.config["agent_llm_provider"], "minimax_cn")
 
     @patch("web_interface.TradingGraph")

--- a/trading_graph.py
+++ b/trading_graph.py
@@ -191,7 +191,7 @@ class TradingGraph:
 
         Args:
             provider: The provider name ("openai", "anthropic", "qwen", "minimax", or "minimax_cn")
-            model: The model name (e.g., "gpt-4o", "claude-3-5-sonnet-20241022", "qwen-vl-max-latest", "MiniMax-M2.7")
+            model: The model name (e.g., "gpt-4o", "claude-3-5-sonnet-20241022", "qwen-vl-max-latest", "MiniMax-M3")
             temperature: The temperature setting for the model
 
         Returns:

--- a/web_interface.py
+++ b/web_interface.py
@@ -31,7 +31,7 @@ MINIMAX_PROVIDER_CONFIG = {
         "fallback_env_keys": (),
         "base_url": "https://api.minimax.io/v1",
         "validation_model": "MiniMax-M2.7-highspeed",
-        "default_model": "MiniMax-M2.7",
+        "default_model": "MiniMax-M3",
     },
     "minimax_cn": {
         "config_key": "minimax_cn_api_key",
@@ -39,7 +39,7 @@ MINIMAX_PROVIDER_CONFIG = {
         "fallback_env_keys": ("MINIMAX_API_KEY",),
         "base_url": "https://api.minimaxi.com/v1",
         "validation_model": "MiniMax-M2.7",
-        "default_model": "MiniMax-M2.7",
+        "default_model": "MiniMax-M3",
     },
 }
 


### PR DESCRIPTION
## Summary

Update the default model for the MiniMax providers (both `minimax` overseas and `minimax_cn`) from `MiniMax-M2.7` to the newer `MiniMax-M3`, which is now the recommended default for new chats.

`MiniMax-M2.7` (and `MiniMax-M2.7-highspeed`) remain valid model IDs and continue to work — they are still used as the lightweight `validation_model` for API-key checks. Only the model picked when a user switches to the MiniMax provider changes.

## Changes

- `web_interface.py` — `default_model` for both `minimax` and `minimax_cn` set to `MiniMax-M3`.
- `trading_graph.py` — docstring example updated to `MiniMax-M3`.
- `tests/test_minimax_provider.py` — assertions for default model on provider switch updated to `MiniMax-M3`; existing tests that pass `MiniMax-M2.7` explicitly are unchanged (they still cover the backward-compatible path).
- `README.md` / `README_CN.md` — example code that demonstrates provider defaults uses `MiniMax-M3`.

`validation_model` is intentionally left at the lighter variants (`MiniMax-M2.7-highspeed` for overseas, `MiniMax-M2.7` for CN) so API-key validation stays cheap and fast.

## Test plan

- [x] `python3 -m unittest tests.test_minimax_provider -v` — all 31 tests pass
- [x] Verified `MiniMax-M3` is accepted by `https://api.minimax.io/v1` (returns a normal upstream response, not an "unknown model" error)
- [ ] Manual switch in web UI: pick "MiniMax" / "MiniMax CN" — both `agent_llm_model` and `graph_llm_model` populate as `MiniMax-M3`