### PR TITLE
fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,4 +316,4 @@ For questions, feedback, or collaboration opportunities, please contact:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Y-Research-SBU/QuantHarness&type=Date)](https://www.star-history.com/#Y-Research-SBU/QuantHarness&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Y-Research-SBU/QuantHarness&type=Date)](https://star-history.dera.page/#Y-Research-SBU/QuantHarness&Date)

--- a/README_CN.md
+++ b/README_CN.md
@@ -307,4 +307,4 @@ python web_interface.py
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Y-Research-SBU/QuantHarness&type=Date)](https://www.star-history.com/#Y-Research-SBU/QuantHarness&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Y-Research-SBU/QuantHarness&type=Date)](https://star-history.dera.page/#Y-Research-SBU/QuantHarness&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders. This updates the chart image and its link in both README.md and README_CN.md to a working alternative that does not require an API token, so the chart displays correctly again.